### PR TITLE
Move app to port 80

### DIFF
--- a/scripts/basic_health_check.sh
+++ b/scripts/basic_health_check.sh
@@ -2,7 +2,7 @@
 
 for i in `seq 1 10`;
 do
-  HTTP_CODE=`curl --write-out '%{http_code}' -o /dev/null -m 10 -q -s http://localhost:4080`
+  HTTP_CODE=`curl --write-out '%{http_code}' -o /dev/null -m 10 -q -s http://localhost:80`
   if [ "$HTTP_CODE" == "200" ]; then
     echo "Successfully pulled root page."
     exit 0;

--- a/scripts/configure_http_port.xsl
+++ b/scripts/configure_http_port.xsl
@@ -9,7 +9,7 @@
 
     <xsl:template match="//Service/Connector[@protocol = 'HTTP/1.1']/@port">
         <xsl:attribute name="port">
-            <xsl:value-of select="'4080'" />
+            <xsl:value-of select="'80'" />
         </xsl:attribute>
     </xsl:template>
 

--- a/scripts/start_application
+++ b/scripts/start_application
@@ -5,7 +5,7 @@ set -e
 CATALINA_HOME='/usr/share/tomcat7-codedeploy'
 DEPLOY_TO_ROOT='true'
 #CONTEXT_PATH='##CONTEXT_PATH##'
-SERVER_HTTP_PORT='4080'
+SERVER_HTTP_PORT='80'
 
 TEMP_STAGING_DIR='/tmp/codedeploy-deployment-staging-area'
 WAR_STAGED_LOCATION="$TEMP_STAGING_DIR/SampleMavenTomcatApp.war"


### PR DESCRIPTION
We need to move this demo app to port 80 instead of 4080 as we run no in-between proxy layer on the instance nor an ELB.